### PR TITLE
openaps support (writes to glucose.json)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * Author: Ben West
  * https://github.com/bewest

--- a/index.js
+++ b/index.js
@@ -305,7 +305,7 @@ function readENV(varName, defaultValue) {
 
 // If run from commandline, run the whole program.
 if (!module.parent) {
-  if (readENV('API_SECRET').length < Defaults.MIN_PASSPHRASE_LENGTH) {
+  if (readENV('API_SECRET') && readENV('API_SECRET').length < Defaults.MIN_PASSPHRASE_LENGTH) {
     var msg = [ "API_SECRET environment variable should be at least"
               , Defaults.MIN_PASSPHRASE_LENGTH, "characters" ];
     var err = new Error(msg.join(' '));

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/bewest/share2nightscout-bridge.git"
   },
   "bin" : {
-    "share2-bridge" : "./index.js",
+    "share2-bridge" : "./index.js"
   },
   "engines": {
     "node": "~0.10.0"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git://github.com/bewest/share2nightscout-bridge.git"
   },
+  "bin" : {
+    "share2-bridge" : "./index.js",
+  },
   "engines": {
     "node": "~0.10.0"
   },


### PR DESCRIPTION
Created option for running interactively as "share2-bridge file glucose.json" to pull and write out to glucose.json the last 5 glucose values.  This will allow openaps to run without a CGM plugged in if it's on wifi and there's a share receiver uploading.

I've tested this works with openaps.  May need to do some regression testing for other use cases if there's anything it looks like I might've broken.
