### PR TITLE
Release share2nightscout-bridge 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ see the [wiki][wiki] for current install information.
 * `maxFailures` (3) - The program will stop running after this many
   consecutively failed login attempts with a clear error message in the logs.
 * `SHARE_INTERVAL` (150000) - The time to wait between each update (default is 2.5 minutes in milliseconds)
+* `NS` - A fully-qualified Nightscout URL (e.g. `https://sitename.herokuapp.com`) which overrides `WEBSITE_HOSTNAME`
 
 #### Azure Specific
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,21 @@ Fetches data from Dexcom's webservice and puts it in Nightscout.
 
 These are required.
 
+Highly recommend setting these as `Custom` type of
+**Connection String** environment variable inside of Azure.
+
+Most people with a pre-existing Nightscout with the API enabled (using
+the `API_SECRET`) will only need to add two more custom connection
+string variables, `DEXCOM_PASSWORD`, and `DEXCOM_ACCOUNT_NAME`.  The
+app uses these details to stay connected, bridging the "data streams"
+over the web.  If the API is not already set up using the
+`API_SECRET`, then the third variable is also needed, set it to any
+long phrase of your choosing, it needs to be longer than 12
+characters.
+
 * **DEXCOM_ACCOUNT_NAME** - Dexcom Share user name
 * **DEXCOM_PASSWORD** - Dexcom Share password
-* **API_SECRET** - (already set in Azure) your Nightscout API Secret
-* **NS** - Your fully qualified `https://foo.bar.example.com` endpoint with no path.
+* **API_SECRET** - (might already be set in Azure) your Nightscout API Secret
 
 #### Features
 
@@ -25,10 +36,23 @@ These features can be used to emulate gap sync.
 * **SHARE_INTERVAL** - default: `60000 * 5`, number of ms to wait between
   updates
 
+#### Old not needed
+
+Deprecated:
+
+* **NS** - Your fully qualified `https://bar.example.com` endpoint
+  with no path.  This is similar to your `/pebble` endpoint, but
+  without the `/pebble` part.
+
+We now look at **`WEBSITE_HOSTNAME`** environment variable, which is set
+automatically by [Azure][azure-environment].
+
+[azure-environment]: https://github.com/projectkudu/kudu/wiki/Azure-runtime-environment
+
 
 ## Output/logs
 
-The output looks like this when it works:
+The output looks something like this when it works:
 ```
 $ env $(cat shansel.env )  node index.js 
 Entries [ { sgv: 70,
@@ -67,4 +91,25 @@ Visit the [releases page][releases], download `nightscout-sidecar.zip`, and
 upload to Azure as a web job.  Set the environment variables above as App Settings.
 
 [releases]: https://github.com/bewest/share2nightscout-bridge/releases
+
+### Prerequisites:
+
+* A working Nightscout web app, and an Azure account.
+* Download `nightscout-sidecar.zip` file from the
+  [releases page][releases]
+
+### Setup
+
+* See [Azure's documentation][create-webjobs] on how to set up and
+  create web jobs.
+* Create a new `Continouous` web job
+  * upload the `nightscout-sidecar.zip` from the [releases page][releases]
+
+[create-webjobs]: http://azure.microsoft.com/en-us/documentation/articles/web-sites-create-web-jobs/
+
+### What to expect
+
+Shortly after creating the webjob, it should start, and your
+Nightscout rig should receive data as usual.
+
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,18 @@ recommended by [Dexcom][dexcom-eula].
 
 #### Azure Account Quotas
 
-We **highly recommend** using this only on the paid Azure Share plans.
-They cost around $10/month.  Using this program with Azure Free
+We **highly recommend** using this only on the paid Azure **Basic** plans.
+They cost around $50/month.  Using this program with Azure Free
 website causes the usage to exceed the free quotas.  Feel free to try
-it out, but watch out for those quotas.
+it out, but watch out for those quotas.  You can partner with family and
+friends to run up to 20 sites on a single plan.  Because you have a
+paid plan, the service will have paid performance and support, with
+better terms on uptimes.  It may be possible to also host mongo on the
+same paid account, in which case it the system will **fail much less
+often**, because of the **Basic** support.
+
+See the [billing comments][billing-issue] for more details and
+feedback.
+
+[billing-issue]: https://github.com/bewest/share2nightscout-bridge/issues/2
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Fetches data from Dexcom's webservice and puts it in Nightscout.
 
+* [Releases][releases]
+* [![wercker status](https://app.wercker.com/status/1d9a86d110cb9d42c844fa60d084e5c4/m "wercker status")](https://app.wercker.com/project/bykey/1d9a86d110cb9d42c844fa60d084e5c4)
+
 ### Environment variables
 
 These are required.

--- a/README.md
+++ b/README.md
@@ -112,4 +112,15 @@ upload to Azure as a web job.  Set the environment variables above as App Settin
 Shortly after creating the webjob, it should start, and your
 Nightscout rig should receive data as usual.
 
+This project is not FDA approved, not recommended for therapy, and not
+recommended by [Dexcom][dexcom-eula].
+
+[dexcom-eula]: http://www.dexcom.com/node/5421
+
+#### Azure Account Quotas
+
+We **highly recommend** using this only on the paid Azure Share plans.
+They cost around $10/month.  Using this program with Azure Free
+website causes the usage to exceed the free quotas.  Feel free to try
+it out, but watch out for those quotas.
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,14 @@ characters.
 
 #### Features
 
-These environment variables are optional.
+These environment variables are optional, you can most likely ignore
+this section.
+These features can be used to emulate gap sync.
+
 * **maxCount** - default: `1`, maximum number of records to process
 * **minutes** - default: `1440`, number of minutes to include
 
-These features can be used to emulate gap sync.
+This one is completely optional.
 
 * **SHARE_INTERVAL** - default: `60000 * 5`, number of ms to wait between
   updates

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dexcom webservice
+# share2nightscout-bridge
 
 Fetches data from Dexcom's webservice and puts it in Nightscout.
 
@@ -57,4 +57,11 @@ If it can log in again, it will continue to re-use the new token to
 fetch data, storing it into Nightscout.
 
 [blog-post]: http://www.hanselman.com/blog/BridgingDexcomShareCGMReceiversAndNightscout.aspx
+
+## How to use/install
+
+Visit the [releases page][releases], download `nightscout-sidecar.zip`, and
+upload to Azure as a web job.  Set the environment variables above as App Settings.
+
+[releases]: https://github.com/bewest/share2nightscout-bridge/releases
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ These features can be used to emulate gap sync.
 
 This one is completely optional.
 
-* **SHARE_INTERVAL** - default: `60000 * 5`, number of ms to wait between
-  updates
+* **SHARE_INTERVAL** - default: `60000 * 2.5`, number of ms to wait between
+  updates.  Default is `2.5` minutes.
 
 #### Old not needed
 
@@ -105,7 +105,7 @@ upload to Azure as a web job.  Set the environment variables above as App Settin
 
 * See [Azure's documentation][create-webjobs] on how to set up and
   create web jobs.
-* Create a new `Continouous` web job
+* Create a new `Continuous` web job
   * upload the `nightscout-sidecar.zip` from the [releases page][releases]
 
 [create-webjobs]: http://azure.microsoft.com/en-us/documentation/articles/web-sites-create-web-jobs/

--- a/index.js
+++ b/index.js
@@ -39,6 +39,35 @@ var Defaults = {
 , nightscout_upload: '/api/v1/entries.json'
 };
 
+var DIRECTIONS = {
+  NONE: 0
+, DoubleUp: 1
+, SingleUp: 2
+, FortyFiveUp: 3
+, Flat: 4
+, FortyFiveDown: 5
+, SingleDown: 6
+, DoubleDown: 7
+, 'NOT COMPUTABLE': 8
+, 'RATE OUT OF RANGE': 9
+};
+var Trends = (function ( ) {
+  var keys = Object.keys(DIRECTIONS);
+  var trends = keys.sort(function (a, b) {
+    return DIRECTIONS[a] - DIRECTIONS[b];
+  });
+  return trends;
+})( );
+function directionToTrend (direction) {
+  var trend = 8;
+  if (direction in DIRECTIONS) {
+    trend = DIRECTIONS[direction];
+  }
+  return trend;
+}
+function trendToDirection (trend) {
+  return Trends[trend] || Trends[0];
+}
 
 // assemble the POST body for the login endpoint
 function login_payload (opts) {
@@ -123,6 +152,7 @@ function dex_to_entry (d) {
   , date: wall
   , dateString: date.toISOString( )
   , trend: d.Trend
+  , direction: trendToDirection(d.Trend)
   , device: 'share2'
   , type: 'sgv'
   // , device: 'dexcom'

--- a/index.js
+++ b/index.js
@@ -258,7 +258,7 @@ if (!module.parent) {
     API_SECRET: readENV('API_SECRET')
   , endpoint: readENV('NS', 'https://' + readENV('WEBSITE_HOSTNAME'))
   };
-  var interval = readENV('SHARE_INTERVAL', 60000 * 5);
+  var interval = readENV('SHARE_INTERVAL', 60000 * 2.5);
   var fetch_config = { maxCount: readENV('maxCount', 1)
     , minutes: readENV('minutes', 1440)
   };

--- a/index.js
+++ b/index.js
@@ -207,20 +207,31 @@ engine.authorize = authorize;
 engine.authorize_fetch = do_everything;
 module.exports = engine;
 
+function readENV(varName, defaultValue) {
+    //for some reason Azure uses this prefix, maybe there is a good reason
+    var value = process.env['CUSTOMCONNSTR_' + varName]
+        || process.env['CUSTOMCONNSTR_' + varName.toLowerCase()]
+        || process.env[varName]
+        || process.env[varName.toLowerCase()];
+
+    return value || defaultValue;
+}
 
 // If run from commandline, run the whole program.
 if (!module.parent) {
   var args = process.argv.slice(2);
   var config = {
-    accountName: process.env['DEXCOM_ACCOUNT_NAME']
-  , password: process.env['DEXCOM_PASSWORD']
+    accountName: readENV('DEXCOM_ACCOUNT_NAME')
+  , password: readENV('DEXCOM_PASSWORD')
   };
   var ns_config = {
-    API_SECRET: process.env['API_SECRET']
-  , endpoint: process.env['NS']
+    API_SECRET: readENV('API_SECRET')
+  , endpoint: readENV('NS', 'https://' + readENV('WEBSITE_HOSTNAME'))
   };
-  var interval = process.env['SHARE_INTERVAL'] || 60000 * 5;
-  var fetch_config = { maxCount: process.env.maxCount || 1, minutes: process.env.minutes || 1440 };
+  var interval = readENV('SHARE_INTERVAL', 60000 * 5);
+  var fetch_config = { maxCount: readENV('maxCount', 1)
+    , minutes: readENV('minutes', 1440)
+  };
   var meta = {
     login: config
   , fetch: fetch_config

--- a/index.js
+++ b/index.js
@@ -235,15 +235,6 @@ function engine (opts) {
   function to_nightscout (glucose) {
     var ns_config = Object.create(opts.nightscout);
     if (glucose) {
-      if (runs === 0) {
-        nullify_battery_status(ns_config, function (err, resp) {
-          if (err) {
-            console.warn('Problem reporting battery', arguments);
-          } else {
-            console.log('Battery status hidden');
-          }
-        });
-      }
       runs++;
       // Translate to Nightscout data.
       var entries = glucose.map(dex_to_entry);
@@ -252,6 +243,15 @@ function engine (opts) {
         opts.callback(null, entries);
       }
       if (ns_config.endpoint) {
+        if (runs === 0) {
+          nullify_battery_status(ns_config, function (err, resp) {
+            if (err) {
+              console.warn('Problem reporting battery', arguments);
+            } else {
+              console.log('Battery status hidden');
+            }
+          });
+        }
         ns_config.entries = entries;
         // Send data to Nightscout.
         report_to_nightscout(ns_config, function (err, response, body) {

--- a/index.js
+++ b/index.js
@@ -248,6 +248,9 @@ function engine (opts) {
       // Translate to Nightscout data.
       var entries = glucose.map(dex_to_entry);
       console.log('Entries', entries);
+      if (opts && opts.callback && opts.callback.call) {
+        opts.callback(null, entries);
+      }
       if (ns_config.endpoint) {
         ns_config.entries = entries;
         // Send data to Nightscout.

--- a/index.js
+++ b/index.js
@@ -28,16 +28,14 @@ var crypto = require('crypto');
 
 
 // Defaults
-var server = "share1.dexcom.com"
+var server = "share1.dexcom.com";
 var bridge = readENV('BRIDGE_SERVER')
     if (bridge && bridge.indexOf(".") > 1) {
     server = bridge;
    } 
     else if (bridge && bridge === 'EU') {
         server = "shareous1.dexcom.com";
-    } else {
-        server = "share1.dexcom.com";
-    }
+    } 
 
 var Defaults = {
   "applicationId":"d89443d2-327c-4a6f-89e5-496bbb0317db"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,24 +1,27 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.1.6",
+  "version": "0.2.0-dev-20190101",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+      "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -36,15 +39,14 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -54,15 +56,10 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -86,12 +83,12 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "extend": {
@@ -105,9 +102,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -120,12 +117,12 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
     },
@@ -143,11 +140,11 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "^5.1.0",
+        "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
       }
     },
@@ -174,8 +171,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -183,9 +179,9 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -204,32 +200,37 @@
       }
     },
     "mime-db": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
     },
     "mime-types": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "requires": {
-        "mime-db": "~1.35.0"
+        "mime-db": "~1.37.0"
       }
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "psl": {
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+    },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -237,30 +238,30 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "request": {
-      "version": "2.87.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
         "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
+        "aws4": "^1.8.0",
         "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "uuid": "^3.3.2"
       }
     },
     "safe-buffer": {
@@ -274,9 +275,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sshpk": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
+      "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -290,11 +291,19 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
+        "psl": "^1.1.24",
         "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
       }
     },
     "tunnel-agent": {
@@ -308,8 +317,15 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "uuid": {
       "version": "3.3.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.2.0-dev-20190101",
+  "version": "0.2.0-dev-20190102",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.2.0-dev-20190102",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Fetches data from Dexcom's webservice and puts it in Nightscout.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.2.0-dev-20190101",
+  "version": "0.2.0-dev-20190102",
   "description": "Fetches data from Dexcom's webservice and puts it in Nightscout.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.1.6",
+  "version": "0.2.0-dev-20190101",
   "description": "Fetches data from Dexcom's webservice and puts it in Nightscout.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Ben West",
-  "license": "GPLv3",
+  "license": "GPL-3.0-only",
   "dependencies": {
-    "request": "^2.87.0"
+    "request": "^2.88.0"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/bewest/share2nightscout-bridge.git"
+    "url": "git://github.com/nightscout/share2nightscout-bridge.git"
   },
   "engines": {
-    "node": "8.x"
+    "node": "10.x || 8.x"
   },
   "keywords": [
     "dexcom",
@@ -25,6 +25,6 @@
     "cgm"
   ],
   "bugs": {
-    "url": "https://github.com/bewest/share2nightscout-bridge/issues"
+    "url": "https://github.com/nightscout/share2nightscout-bridge/issues"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexcom-share-web",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Fetches data from Dexcom's webservice and puts it in Nightscout.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Fetches data from Dexcom's webservice and puts it in Nightscout.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Fetches data from Dexcom's webservice and puts it in Nightscout.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.2.0-dev-20190102",
+  "version": "0.2.0",
   "description": "Fetches data from Dexcom's webservice and puts it in Nightscout.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,27 @@
 {
-  "name": "dexcom-share-web",
+  "name": "share2nightscout-bridge",
   "version": "0.0.1",
-  "description": "",
+  "description": "Fetches data from Dexcom's webservice and puts it in Nightscout.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
-  "license": "BSD-2-Clause",
+  "author": "Ben West",
+  "license": "GPLv3",
   "dependencies": {
     "request": "~2.53.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/bewest/share2nightscout-bridge.git"
+  },
+  "keywords": [
+    "dexcom",
+    "bridge",
+    "nightscout",
+    "cgm"
+  ],
+  "bugs": {
+    "url": "https://github.com/bewest/share2nightscout-bridge/issues"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Fetches data from Dexcom's webservice and puts it in Nightscout.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Fetches data from Dexcom's webservice and puts it in Nightscout.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Fetches data from Dexcom's webservice and puts it in Nightscout.",
   "main": "index.js",
   "scripts": {

--- a/wercker.yml
+++ b/wercker.yml
@@ -5,6 +5,7 @@ build:
       - script:
           name: "install prereqs"
           code: |-
+              sudo apt-get update
               sudo apt-get install -y zip
       - script:
           name: "npm install"


### PR DESCRIPTION
Changes:
- first release since @bewest. share2nightscout-bridge is now temporary maintained by @sulkaharo and @PieterGit because it's a Nightscout core plugin
- formalize the changes from `wip/generalize` to a released version
- change from `wip/generalize` to `dev` branch, just like oref0 and Nightscout do
- https://github.com/nightscout/share2nightscout-bridge/pull/33 Check res before checking res.statusCode to prevent Nightscout server crashes in case Dexcom server does not respond
- upgrade `request` package
- upgrade node to Node 8 or Node 10 LTS
- publish on npm.org https://www.npmjs.com/package/share2nightscout-bridge . I will publish as a  final `0.2.0` if I get confirmation that https://github.com/nightscout/cgm-remote-monitor/pull/4175 works within Nightscout.
