### PR TITLE
Dev - prep for next release

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ var bridge = readENV('BRIDGE_SERVER')
     server = bridge;
    } 
     else if (bridge && bridge === 'EU') {
-        server = "shareous1.dexcom.com";
+        server = "shareous2.dexcom.com";
     } 
 
 var Defaults = {

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@
 var request = require('request');
 var qs = require('querystring');
 var crypto = require('crypto');
+var meta = require('./package.json');
 
 
 // Defaults
@@ -37,9 +38,10 @@ var bridge = readENV('BRIDGE_SERVER')
         server = "shareous2.dexcom.com";
     } 
 
+
 var Defaults = {
   "applicationId":"d89443d2-327c-4a6f-89e5-496bbb0317db"
-, "agent": "Dexcom Share/3.0.2.11 CFNetwork/711.2.23 Darwin/14.0.0"
+, "agent": [meta.name, meta.version].join('/')
 , login: 'https://' + server + '/ShareWebServices/Services/General/LoginPublisherAccountByName'
 , accept: 'application/json'
 , 'content-type': 'application/json'

--- a/index.js
+++ b/index.js
@@ -28,16 +28,14 @@ var crypto = require('crypto');
 
 
 // Defaults
-var server = "share1.dexcom.com"
+var server = "share1.dexcom.com";
 var bridge = readENV('BRIDGE_SERVER')
     if (bridge && bridge.indexOf(".") > 1) {
     server = bridge;
    } 
     else if (bridge && bridge === 'EU') {
         server = "shareous1.dexcom.com";
-    } else {
-        server = "share1.dexcom.com";
-    }
+    } 
 
 var Defaults = {
   "applicationId":"d89443d2-327c-4a6f-89e5-496bbb0317db"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.2.0-dev-20190101",
+  "version": "0.2.0-dev-20190102",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.2.0-dev-20190102",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.2.0-dev-20190101",
+  "version": "0.2.0-dev-20190102",
   "description": "Fetches data from Dexcom's webservice and puts it in Nightscout.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "share2nightscout-bridge",
-  "version": "0.2.0-dev-20190102",
+  "version": "0.2.0",
   "description": "Fetches data from Dexcom's webservice and puts it in Nightscout.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/nightscout/share2nightscout-bridge.git"
   },
   "engines": {
-    "node": "10.x || 8.x"
+    "node": "12.x || 10.x || 8.x"
   },
   "keywords": [
     "dexcom",


### PR DESCRIPTION

> With the recently announced https://www.dexcom.com/obsolescence Dexcom G4/G5 changes, we will need to switch servers.
https://github.com/nightscout/share2nightscout-bridge/pull/38#issue-397793895

In addition:
* set user-agent to `name/version` from package.json
* mark as compatible with node 12
