### PR TITLE
Support Trend as a number and now as a string, Dexcom EU changed the type of Trend to string

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,45 @@ var DIRECTIONS = {
 , 'NOT COMPUTABLE': 8
 , 'RATE OUT OF RANGE': 9
 };
+function stringLowerCaseNoSpaces(str) {
+  str = str.toLowerCase()
+  while(str.indexOf(' ')>-1)
+    str = str.replace(' ','');
+  return str;
+}
+
+
+function copyObjectWithLowercaseKeys(obj) {
+  // return a copy of obj but with each key transformed to lowercase
+  // and spaces removed
+  return Object.keys(obj).reduce(function (result, key)  {
+    var newKey = stringLowerCaseNoSpaces(key);
+    result[newKey] = obj[key];
+    return result
+  }, {});
+}
+
+var LCDIRECTIONS = copyObjectWithLowercaseKeys(DIRECTIONS);
+
+
+function matchTrend(trend) {
+  // attempt to match the trend based on
+  // a) it is a number
+  // b) it matches a key in DIRECTIONS
+  // c) it matches a key in LCDIRECTIONS if converted to lowercase and all spaces removed
+
+  if (typeof(trend) !== "string")
+    return trend;
+
+  if (trend in DIRECTIONS)
+    return DIRECTIONS[trend];
+    
+  var lctrend = stringLowerCaseNoSpaces(trend);
+
+  if (lctrend in LCDIRECTIONS) return LCDIRECTIONS[lctrend];
+  return trend;
+}
+
 var Trends = (function ( ) {
   var keys = Object.keys(DIRECTIONS);
   var trends = keys.sort(function (a, b) {
@@ -202,11 +241,7 @@ function dex_to_entry (d) {
   var regex = /\((.*)\)/;
   var wall = parseInt(d.WT.match(regex)[1]);
   var date = new Date(wall);
-  var trend = d.Trend;
-
-  if (typeof(trend) === "string" and trend in DIRECTION) {
-    trend = DIRECTIONS[trend];
-  }
+  var trend = matchTrend(d.Trend);
   
   var entry = {
     sgv: d.Value

--- a/index.js
+++ b/index.js
@@ -202,12 +202,18 @@ function dex_to_entry (d) {
   var regex = /\((.*)\)/;
   var wall = parseInt(d.WT.match(regex)[1]);
   var date = new Date(wall);
+  var trend = d.Trend;
+
+  if (typeof(trend) === "string" and trend in DIRECTION) {
+    trend = DIRECTIONS[trend];
+  }
+  
   var entry = {
     sgv: d.Value
   , date: wall
   , dateString: date.toISOString( )
-  , trend: d.Trend
-  , direction: trendToDirection(d.Trend)
+  , trend: trend
+  , direction: trendToDirection(trend)
   , device: 'share2'
   , type: 'sgv'
   };

--- a/tests/authorize_fetch.test.js
+++ b/tests/authorize_fetch.test.js
@@ -26,7 +26,12 @@ describe("authorize_fetch", () => {
 					.be.an.instanceOf(Object);
 				glucose[0].DT.should.be.a.String().and.containEql("Date");
 				glucose[0].ST.should.be.a.String().and.containEql("Date");
-				glucose[0].Trend.should.be.a.Number();
+				glucose[0].Trend.should.exist();
+				if (typeof glucose[0].Trend === "string") {
+					glucose[0].Trend.should.be.a.String();
+				} else {				
+					glucose[0].Trend.should.be.a.Number();
+				}
 				glucose[0].Value.should.be.a.Number();
 				glucose[0].WT.should.be.a.String().and.containEql("Date");
 


### PR DESCRIPTION
At 2021-11-30 17:00+UTC I found that, in the EU region, the Dexcom API switched the format of the Trend property.

Where as previously, the Trend property was a number, it is now a string. This breaks the direction feature.

here's a snip from my logs after the change:

```
Entries [ {
  WT: 'Date(1638301612000)',
  ST: 'Date(1638301612000)',
  DT: 'Date(1638301612000+0000)',
  Value: 84,
  Trend: 'Flat' // Previously this would've been 4
}
```

This change converts the string value back to an integer by finding the correct value in the DIRECTIONS object.

This restores the direction feature

It is unlikely to be rigorous since I don't now all the string values Dexcom will now return for Trend, but it certainly works for common values (up arrows, down arrows and flat)